### PR TITLE
Remove stale Logto comment

### DIFF
--- a/src/lib/context/user-context-provider.tsx
+++ b/src/lib/context/user-context-provider.tsx
@@ -78,7 +78,6 @@ export const useSetGlobalOrganizationIdInUserContext = () => {
 	}
 
 	return (organizationId: string) => {
-		//todo remove when Logto introduces refreshToken on demand
 		localStorage.setItem('organizationId', organizationId);
 		context.setOrganizationId(organizationId);
 		context.setIsGlobalOrg(true);


### PR DESCRIPTION
## Summary
- Logto was replaced by better-auth in `00579a4`. One stale TODO comment in `user-context-provider.tsx` still referenced Logto's missing `refreshToken on demand`. Removed.
- The `localStorage` workaround the comment sits next to is intentionally kept — the surrounding code still relies on it under better-auth (see the existing comment at lines 32–33).

## Test plan
- [ ] Comment-only change; behavior is identical. Sanity-check by running the app and signing in.