### PR TITLE
Remove unused lodash chain import

### DIFF
--- a/src/components/transaction-page/l2-transaction-details.tsx
+++ b/src/components/transaction-page/l2-transaction-details.tsx
@@ -2,7 +2,6 @@ import { useSettings } from '@/lib/context/settings-context-provider';
 import { formatTimestampToUTC } from '@/lib/utils';
 import { InfoBox, InfoBoxItem } from '../ui/info-box';
 import { L2TransactionData } from '@/lib/simulation';
-import { chain } from 'lodash';
 
 export function TransactionDetails({
 	transactionData,


### PR DESCRIPTION
## Summary
- Removes the unused `chain` import from `lodash` in `l2-transaction-details.tsx`. It is imported but never referenced anywhere in the file.

## Test plan
- [x] `npx eslint src/components/transaction-page/l2-transaction-details.tsx` passes
- [x] Diff is a single-line removal, no behavior change