### PR TITLE
Remove duplicate horizontal rule in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,8 +104,6 @@ NEXT_PUBLIC_CHAIN_ID="11155420"
 
 ---
 
----
-
 ### 3. Install Dependencies & Build
 
 ```sh


### PR DESCRIPTION
## Summary
- Removes a duplicate \`---\` separator between sections 2 and 3 of the Local Setup guide in README.md.

## Test plan
- [x] Diff is two lines removed, pure markdown cleanup