### PR TITLE
Fix TOC indentation for 'Run the Debugger' section

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@
   - [1. Install Prerequisites](#1-install-prerequisites)
   - [2. Set Up Environment Variables](#2-set-up-environment-variables)
   - [3. Install Dependencies \& Build](#3-install-dependencies--build)
-- [4. Run the Debugger](#4-run-the-debugger)
+  - [4. Run the Debugger](#4-run-the-debugger)
 - [Contributing](#contributing)
 - [Acknowledgements](#acknowledgements)
 - [License](#license)


### PR DESCRIPTION
## Summary
- The \"4. Run the Debugger\" entry in the README table of contents was missing two leading spaces, so it rendered at the top level instead of nesting under \"Local Setup & Usage\" alongside items 1–3.

## Test plan
- [x] Diff is a single-line indentation fix