### PR TITLE
Remove unused isAddressInUse helper in anvil module

### DIFF
--- a/src/app/api/v1/anvil.ts
+++ b/src/app/api/v1/anvil.ts
@@ -1,21 +1,5 @@
 import { ChildProcessWithoutNullStreams, spawn } from 'node:child_process';
-import { createServer } from 'node:net';
 import { type Hash } from 'viem';
-
-const isAddressInUse = (port: number, hostname: string) =>
-	new Promise<boolean>((resolve) => {
-		const server = createServer();
-		server.once('error', ({ code }: { code: string }) => {
-			if (code === 'EADDRINUSE') {
-				resolve(false);
-			}
-		});
-		server.once('listening', () => {
-			resolve(true);
-			server.close();
-		});
-		server.listen(port, hostname);
-	});
 
 const waitForOutput = ({ stdout }: ChildProcessWithoutNullStreams, output: string) =>
 	new Promise<void>((resolve) => {
@@ -40,10 +24,6 @@ export const spawnAnvil = async ({
 	txHash?: Hash;
 	blockNumber?: bigint;
 }) => {
-	/* const addressInUse = await isAddressInUse(port, hostname);
-	if (addressInUse) {
-		return;
-	} */
 	const anvil = spawn('anvil', [
 		'--port',
 		port.toString(),


### PR DESCRIPTION
## Summary
- \`isAddressInUse\` and its only call site in \`spawnAnvil\` were commented out; the function and its \`createServer\` import were unreferenced. Deletes the helper, the unused import, and the commented-out call block.

## Test plan
- [x] \`grep -rn "isAddressInUse" src\` returns no other usages
- [x] \`createServer\` from \`node:net\` is not used elsewhere in the file
- [x] No behavior change — removed code was already inert